### PR TITLE
Compatibility with Rails 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Suppressing RangeError during type casting.
 
 > For Rails 5.x and older, use the v0.x releases of this gem.
 
-> For Rails 6.x and earlier, use the v1.x releases of this gem.
+> For Rails 6.x and later, use the v1.x releases of this gem.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Suppressing RangeError during type casting.
 
-> This gem is not needed in Rails 6, it was incorporated by framework. Use it only with Rails 5.x and older. See [details](https://github.com/kamipo/activerecord-suppress_range_error/issues/3)
+> For Rails 5.x and older, use the v0.x releases of this gem.
+
+> For Rails 6.x and earlier, use the v1.x releases of this gem.
 
 ## Installation
 

--- a/lib/active_record/suppress_range_error.rb
+++ b/lib/active_record/suppress_range_error.rb
@@ -5,6 +5,7 @@ module ActiveRecord
     private
 
     def ensure_in_range(value)
+      value
     end
   end
 

--- a/lib/active_record/suppress_range_error/version.rb
+++ b/lib/active_record/suppress_range_error/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module SuppressRangeError
-    VERSION = "0.1.1"
+    VERSION = "1.0.0"
   end
 end


### PR DESCRIPTION
Hey @kamipo! 👋 

I've updated the gem to be compatible with Rails 6 "internal" behavior, that returns the parameter passed in `ensure_in_range` ( https://github.com/rails/rails/blob/v6.0.3.4/activemodel/lib/active_model/type/integer.rb#L38-L43 ), in opposite of Rails 5 "internal" behavior, that not return anything ( https://github.com/rails/rails/blob/v5.2.4.4/activemodel/lib/active_model/type/integer.rb#L51-L55 ).

This PR adds compatiblity with rails 6, and also allow developers to have a workaround for this ransack bug: https://github.com/activerecord-hackery/ransack/issues/1064

Glad to see it reviewed! Thanks a lot!